### PR TITLE
Update 'info' endpoint to respond with 200 OK and operator info

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -94,12 +94,7 @@ func (ar *apiRouter) GetOperatorInfo(w http.ResponseWriter, r *http.Request) err
 		return writeJSONError(w, err)
 	}
 
-	// No cred events found
-	if len(operatorInfo.CredentialEvents) == 0 {
-		return writeJSONResponse(w, http.StatusNotFound, operatorInfo, "")
-	}
-
-	// Cred events found
+	// Cred events retrieved
 	ar.logger.Info("Retrieved operator info",
 		zap.String("nodeID", req.Address),
 		zap.Int("operator_type", int(req.operatorType)),

--- a/services/operator_info.go
+++ b/services/operator_info.go
@@ -47,21 +47,17 @@ func (s *Service) GetOperatorInfo(msg []byte, sig []byte, ot credentials.Operato
 		}
 	}
 
-	// Return empty if no cred events found
-	if credCount == 0 {
-		s.logger.Info(
-			"No creds found for operator",
-			zap.String("nodeID", nodeID.String()),
-		)
-		return &OperatorInfo{[]int64{}}, nil
-	}
-
 	s.logger.Info(
 		"Retrieved operator info",
 		zap.String("nodeID", nodeID.String()),
 		zap.String("operatorType", ot.String()),
 	)
 	s.m.Counter("retrieved_operator_info").Inc()
+
+	// Return empty if no cred events found
+	if credCount == 0 {
+		return &OperatorInfo{[]int64{}}, nil
+	}
 
 	return &OperatorInfo{CredentialEvents: events}, nil
 }

--- a/services/operator_info.go
+++ b/services/operator_info.go
@@ -32,7 +32,7 @@ func (s *Service) GetOperatorInfo(msg []byte, sig []byte, ot credentials.Operato
 	defer rows.Close()
 
 	// Parse credential events
-	var events []int64
+	var events = []int64{}
 	var credCount int64 = 0
 	for rows.Next() {
 		row_timestamp := int64(0)
@@ -53,11 +53,6 @@ func (s *Service) GetOperatorInfo(msg []byte, sig []byte, ot credentials.Operato
 		zap.String("operatorType", ot.String()),
 	)
 	s.m.Counter("retrieved_operator_info").Inc()
-
-	// Return empty if no cred events found
-	if credCount == 0 {
-		return &OperatorInfo{[]int64{}}, nil
-	}
 
 	return &OperatorInfo{CredentialEvents: events}, nil
 }


### PR DESCRIPTION
Updates the 'info' endpoint to respond with 200 OK, an empty credential array, and respective quota settings when a valid request is received from a registered node operator, but no credential events are found.

Changes previous behavior where 404 was sent with an empty credential array and no quota settings under the same circumstances.