### PR TITLE
Update GetQuotaJson() to return quota windows measured in seconds

### DIFF
--- a/services/credentials.go
+++ b/services/credentials.go
@@ -88,8 +88,8 @@ func AuthValidityWindow(ot credentials.OperatorType) time.Duration {
 func GetQuotaJSON(ot credentials.OperatorType) (json.RawMessage, error) {
 	quotaData := map[string]interface{}{
 		"count":              uint(credsQuota(ot)),
-		"window":             credsQuotaWindow(ot),
-		"authValidityWindow": AuthValidityWindow(ot),
+		"window":             int64(credsQuotaWindow(ot).Seconds()),
+		"authValidityWindow": int64(AuthValidityWindow(ot).Seconds()),
 	}
 
 	quotaJson, err := json.Marshal(quotaData)

--- a/services/credentials_test.go
+++ b/services/credentials_test.go
@@ -350,7 +350,7 @@ func TestGetQuotaJson(t *testing.T) {
 		t.Fatalf("Error parsing window from quota json")
 	}
 	window := int64(fWindow)
-	if window != int64(credsQuotaWindow(pb.OperatorType_OT_ROCKETPOOL)) {
+	if window != int64(credsQuotaWindow(pb.OperatorType_OT_ROCKETPOOL).Seconds()) {
 		t.Fatalf("Incorrect quota window. Expected %d, got %d", int64(credsQuotaWindow(pb.OperatorType_OT_ROCKETPOOL)), window)
 	}
 
@@ -360,7 +360,7 @@ func TestGetQuotaJson(t *testing.T) {
 	if !ok {
 		t.Fatalf("Error parsing authValidityWindow from quota json")
 	}
-	if authValidityWindow != int64(AuthValidityWindow(pb.OperatorType_OT_ROCKETPOOL)) {
+	if authValidityWindow != int64(AuthValidityWindow(pb.OperatorType_OT_ROCKETPOOL).Seconds()) {
 		t.Fatalf("Incorrect quota authValidityWindow. Expected %d,  got %d", AuthValidityWindow(pb.OperatorType_OT_ROCKETPOOL), authValidityWindow)
 	}
 }


### PR DESCRIPTION
Updates GetQuotaJson() to return quota windows measured in seconds. This is more practical for consumers of the '/info' endpoint.